### PR TITLE
fix: chisel manifest formatting

### DIFF
--- a/app/util/chisel.py
+++ b/app/util/chisel.py
@@ -29,8 +29,7 @@ stringData:
 ---
 """
     for suffix in suffixes:
-      manifest += f"""
-apiVersion: chisel-operator.io/v1
+      manifest += f"""apiVersion: chisel-operator.io/v1
 kind: ExitNode
 metadata:
   name: {suffix}
@@ -40,6 +39,7 @@ spec:
   port: 9090
   auth: selfhosted
 ---
+YAML
 """
 
     return manifest


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed formatting issues in the `create_chisel_yaml` function.

- Corrected YAML manifest generation for Chisel ExitNode.

- Improved readability and consistency of generated YAML.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chisel.py</strong><dd><code>Fix and improve YAML manifest formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/util/chisel.py

<li>Fixed indentation and formatting in YAML string generation.<br> <li> Adjusted the <code>apiVersion</code> line to align properly.<br> <li> Ensured consistent YAML output for Chisel ExitNode manifests.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/tools-api/pull/7/files#diff-eeb9380784e267897e586cdfd91d07bf66f596d496c62d9313a8ae71583f3281">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information