### PR TITLE
fix: cloud-init script for hetzner

### DIFF
--- a/app/util/hetzner.py
+++ b/app/util/hetzner.py
@@ -22,7 +22,7 @@ def multiline_to_singleline(input_text: str) -> str:
     Returns:
         str: Single-line string with `\\n` replacing newlines.
     """
-    return input_text.replace("\n", "\\n")
+    return input_text.replace("\n", "\n")
 
 
 def create_instances(request):
@@ -30,11 +30,12 @@ def create_instances(request):
     credentials_for_chisel = util.chisel.generate_credentials()
 
     # Define user data
-    user_data_readable = f"""#cloud-config
+    user_data_readable = f"""
+#cloud-config
 package_update: true
 runcmd:
-- curl -fsSL https://get.docker.com -o get-docker.sh && sudo sh get-docker.sh && sudo apt install tmux -y
-- sudo docker run -d --restart always -p 9090:9090 -p 443:443 -p 80:80 -it jpillora/chisel:v1.10.1 server --reverse --port=9090 --auth='{credentials_for_chisel}'
+    - curl -fsSL https://get.docker.com -o get-docker.sh && sudo sh get-docker.sh && sudo apt install tmux -y
+    - sudo docker run -d --restart always -p 9090:9090 -p 443:443 -p 80:80 -it docker.io/jpillora/chisel:1.10.1 server --reverse --port=9090 --auth='{credentials_for_chisel}'
 """
 
     user_data = multiline_to_singleline(user_data_readable)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect newline replacement in `multiline_to_singleline` function.

- Updated `user_data_readable` formatting for better readability.

- Corrected Docker image reference in cloud-init script.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hetzner.py</strong><dd><code>Fix cloud-init script and improve formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/util/hetzner.py

<li>Fixed newline replacement in <code>multiline_to_singleline</code> function.<br> <li> Adjusted <code>user_data_readable</code> formatting for clarity.<br> <li> Updated Docker image reference to use <code>docker.io</code> prefix.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/tools-api/pull/10/files#diff-03be9010a809279b5cdb19be3c31286da045b43684bea2a91e22bf7985dd8321">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information