### PR TITLE
fix: formatting for otel storage

### DIFF
--- a/app/util/storage.py
+++ b/app/util/storage.py
@@ -69,7 +69,7 @@ def parameterize_storage_config(bucket_prefix):
     """
     # Example usage
     template = """
-      loki_storage         = <<EOT
+      loki_storage   = <<EOT
 bucketNames:
         chunks: {loki_bucket}
         ruler: {loki_bucket}
@@ -84,7 +84,7 @@ bucketNames:
       s3ForcePathStyle: false
       insecure: false
     EOT
-      thanos_storage       = <<EOT
+      thanos_storage = <<EOT
 type: s3
     config:
         bucket: {thanos_bucket}
@@ -92,7 +92,7 @@ type: s3
         access_key: {access_key}
         secret_key: {secret_key}
 EOT
-      tempo_storage        = <<EOT
+      tempo_storage  = <<EOT
 backend: s3
     s3:
         access_key: {access_key}

--- a/app/util/storage.py
+++ b/app/util/storage.py
@@ -69,22 +69,22 @@ def parameterize_storage_config(bucket_prefix):
     """
     # Example usage
     template = """
-    loki_storage         = <<EOT
+      loki_storage         = <<EOT
 bucketNames:
         chunks: {loki_bucket}
         ruler: {loki_bucket}
         admin: {loki_bucket}
-    type: s3
-    s3:
-        s3: {loki_bucket}
-        endpoint: https://{region}.your-objectstorage.com
-        region: us-east-1
-        accessKeyId: {access_key}
-        secretAccessKey: {secret_key}
-        s3ForcePathStyle: false
-        insecure: false
+   type: s3
+   s3:
+      s3: {loki_bucket}
+      endpoint: https://{region}.your-objectstorage.com
+      region: us-east-1
+      accessKeyId: {access_key}
+      secretAccessKey: {secret_key}
+      s3ForcePathStyle: false
+      insecure: false
     EOT
-        thanos_storage       = <<EOT
+      thanos_storage       = <<EOT
 type: s3
     config:
         bucket: {thanos_bucket}
@@ -92,7 +92,7 @@ type: s3
         access_key: {access_key}
         secret_key: {secret_key}
 EOT
-        tempo_storage        = <<EOT
+      tempo_storage        = <<EOT
 backend: s3
     s3:
         access_key: {access_key}


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed indentation issues in `parameterize_storage_config` template.

- Ensured valid HCL formatting for storage configurations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage.py</strong><dd><code>Fixed indentation and spacing in storage templates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/util/storage.py

<li>Corrected indentation for <code>loki_storage</code>, <code>thanos_storage</code>, and <br><code>tempo_storage</code>.<br> <li> Adjusted spacing to ensure valid HCL formatting.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/tools-api/pull/17/files#diff-7061a9be236a56df745cc8c78f764ec73221ffa2d09ea2ac06f25c223184995a">+12/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>