### PR TITLE
feat: migrate to registry caches

### DIFF
--- a/app/util/chisel.py
+++ b/app/util/chisel.py
@@ -38,7 +38,7 @@ spec:
   host: "{ip_addresses[f'{captain_domain}-{suffix}']}"
   port: 9090
   auth: selfhosted
-  chisel_image: ghcr.io/fyralabs/chisel:v0.1.0-fyra
+  chisel_image: replicas.mirror.gpkg.io/proxy-ghcr-io/fyralabs/chisel:v0.1.0-fyra
 ---
 """
     manifest += f"""


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update chisel image registry from ghcr.io to replicas.mirror.gpkg.io


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ghcr.io registry"] -- "migrate to" --> B["replicas.mirror.gpkg.io cache"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chisel.py</strong><dd><code>Migrate chisel image to registry cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/util/chisel.py

<ul><li>Update chisel image registry URL from ghcr.io to <br>replicas.mirror.gpkg.io proxy</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/tools-api/pull/58/files#diff-eeb9380784e267897e586cdfd91d07bf66f596d496c62d9313a8ae71583f3281">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

