### PR TITLE
chore: Remove concurrency from cleanup-images job

### DIFF
--- a/.github/workflows/cleanup_images.yaml
+++ b/.github/workflows/cleanup_images.yaml
@@ -8,13 +8,9 @@ on:
 jobs:
   cleanup-images:
     runs-on: ubuntu-latest
-    concurrency:
-      group: cleanup-ghcr-images
-      cancel-in-progress: false
     permissions:
       packages: write
     steps:
-
       - name: Cleanup old images
         uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:


### PR DESCRIPTION
Removed concurrency settings from cleanup job.