### PR TITLE
feat: add /v1/kube-rbac endpoint for developer-debug RBAC

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,8 +5,8 @@ from typing import Optional, Dict, List
 from pydantic import BaseModel, Field
 from contextlib import asynccontextmanager
 import os, glueops.setup_logging, traceback, base64, yaml, tempfile, json
-from schemas.schemas import Message, AwsCredentialsRequest, StorageBucketsRequest, AwsNukeAccountRequest, CaptainDomainNukeDataAndBackupsRequest, ChiselNodesRequest, ChiselNodesDeleteRequest, ResetGitHubOrganizationRequest, OpsgenieAlertsManifestRequest, IncidentioAlertsManifestRequest, CaptainManifestsRequest, KubeApiserverManifestRequest, GitHubWorkflowRunStatusRequest, VersionResponse
-from util import storage, aws_setup_test_account_credentials, github, hetzner, opsgenie, incidentio, captain_manifests, kube_apiserver
+from schemas.schemas import Message, AwsCredentialsRequest, StorageBucketsRequest, AwsNukeAccountRequest, CaptainDomainNukeDataAndBackupsRequest, ChiselNodesRequest, ChiselNodesDeleteRequest, ResetGitHubOrganizationRequest, OpsgenieAlertsManifestRequest, IncidentioAlertsManifestRequest, CaptainManifestsRequest, KubeApiserverManifestRequest, KubeRbacManifestRequest, GitHubWorkflowRunStatusRequest, VersionResponse
+from util import storage, aws_setup_test_account_credentials, github, hetzner, opsgenie, incidentio, captain_manifests, kube_apiserver, kube_rbac
 from fastapi.responses import RedirectResponse
 
 
@@ -151,6 +151,17 @@ async def create_kube_apiserver_manifest(request: KubeApiserverManifestRequest):
         providers.kubernetesCRD.allowCrossNamespace=true or the route is silently dropped.
     """
     return kube_apiserver.create_kube_apiserver_manifest(request)
+
+@app.post("/v1/kube-rbac", response_class=PlainTextResponse, summary="Generate developer-debug RBAC (reader/debugger/operator) for a tenant's namespace")
+async def create_kube_rbac_manifest(request: KubeRbacManifestRequest):
+    """
+        Generate the ClusterRoles + namespace-scoped RoleBindings that let a tenant's developers
+        debug their workloads (Lens/k9s) in their <environment> namespace via the kube-apiserver
+        exposed by /v1/kube-apiserver. The namespace is the first label of captain_domain and the
+        RoleBinding subjects are oidc:<tenant_github_organization_name>:<captain_domain>-<role>.
+        Also includes the hardcoded glueops-super-admins -> cluster-admin ClusterRoleBinding.
+    """
+    return kube_rbac.create_kube_rbac_manifest(request)
 
 @app.post("/v1/captain-manifests", response_class=PlainTextResponse, summary="Generate captain manifests")
 async def create_captain_manifests(request: CaptainManifestsRequest):

--- a/app/schemas/schemas.py
+++ b/app/schemas/schemas.py
@@ -80,6 +80,18 @@ class KubeApiserverManifestRequest(BaseModel):
         description='Comma-separated CIDR ranges allowed to reach the kube-apiserver; at least one required. Replace the example (RFC 5737 documentation ranges) with your own IPs.'
     )
 
+class KubeRbacManifestRequest(BaseModel):
+    captain_domain: str = Field(
+        ...,
+        example='nonprod.foobar.onglueops.rocks',
+        description='RoleBinding namespace = first label (e.g. "nonprod"); also the OIDC group suffix.'
+    )
+    tenant_github_organization_name: str = Field(
+        ...,
+        example='development-tenant-foobar',
+        description='OIDC group prefix: oidc:<org>:<captain_domain>-<reader|debugger|operator>.'
+    )
+
 class GitHubWorkflowRunStatusRequest(BaseModel):
     run_url: str = Field(..., example='https://github.com/internal-GlueOps/gha-tools-api/actions/runs/12345678')
 

--- a/app/util/kube_rbac.py
+++ b/app/util/kube_rbac.py
@@ -1,0 +1,281 @@
+import re
+from fastapi import HTTPException
+
+# RFC 1123 DNS hostname (multi-label). Mirrors kube_apiserver.py's _HOSTNAME_RE; kept local so this
+# module stays independent (same low-coupling style as opsgenie.py / incidentio.py).
+_HOSTNAME_RE = re.compile(
+    r'^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$'
+)
+# GitHub org login: 1-39 chars, alphanumerics or single non-leading/trailing hyphens.
+_GITHUB_ORG_RE = re.compile(r'^[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}$')
+
+
+def create_kube_rbac_manifest(request):
+    captain_domain = request.captain_domain.strip()
+    if not _HOSTNAME_RE.match(captain_domain):
+        raise HTTPException(status_code=422, detail="Invalid captain_domain.")
+
+    tenant_org = request.tenant_github_organization_name.strip()
+    if not _GITHUB_ORG_RE.match(tenant_org):
+        raise HTTPException(status_code=422, detail="Invalid tenant_github_organization_name.")
+
+    namespace = captain_domain.split('.')[0]          # environment_name (e.g. "nonprod")
+    group = f"oidc:{tenant_org}:{captain_domain}"      # append -reader / -debugger / -operator
+
+    manifest = f"""# GlueOps developer-debug RBAC for kube-apiserver access (Lens / k9s).
+# No aggregationRules (conflicts with ArgoCD) -- each role repeats the read set; keep them in sync.
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: glueops-reader
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/status
+      - pods/log
+      - services
+      - endpoints
+      - configmaps
+      - events
+      - persistentvolumeclaims
+      - serviceaccounts
+      - resourcequotas
+      - limitranges
+      - replicationcontrollers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["controllerrevisions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications", "applicationsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["external-secrets.io"]
+    resources: ["externalsecrets", "secretstores"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["traefik.io"]  # add "traefik.containo.us" on older Traefik v2
+    resources: ["ingressroutes", "ingressroutetcps", "middlewares", "middlewaretcps"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: glueops-debugger
+rules:
+  # read set (in sync with glueops-reader)
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/status
+      - pods/log
+      - services
+      - endpoints
+      - configmaps
+      - events
+      - persistentvolumeclaims
+      - serviceaccounts
+      - resourcequotas
+      - limitranges
+      - replicationcontrollers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["controllerrevisions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications", "applicationsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["external-secrets.io"]
+    resources: ["externalsecrets", "secretstores"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["traefik.io"]
+    resources: ["ingressroutes", "ingressroutetcps", "middlewares", "middlewaretcps"]
+    verbs: ["get", "list", "watch"]
+  # debug verbs
+  - apiGroups: [""]
+    resources:
+      - pods/exec
+      - pods/attach
+      - pods/portforward
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/ephemeralcontainers"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["apps"]  # rollout restart (patch restartedAt); selfHeal may revert
+    resources: ["deployments", "statefulsets", "daemonsets"]
+    verbs: ["patch"]
+  - apiGroups: [""]  # delete a stuck pod (selfHeal-safe restart)
+    resources: ["pods"]
+    verbs: ["delete"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: glueops-operator
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/status
+      - pods/log
+      - services
+      - endpoints
+      - configmaps
+      - events
+      - persistentvolumeclaims
+      - serviceaccounts
+      - resourcequotas
+      - limitranges
+      - replicationcontrollers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["controllerrevisions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications", "applicationsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["external-secrets.io"]
+    resources: ["externalsecrets", "secretstores"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["traefik.io"]
+    resources: ["ingressroutes", "ingressroutetcps", "middlewares", "middlewaretcps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - pods/exec
+      - pods/attach
+      - pods/portforward
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/ephemeralcontainers"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets"]
+    verbs: ["patch"]
+  - apiGroups: ["*"]  # delete any namespaced resource (incl. secrets/PVCs/rolebindings)
+    resources: ["*"]
+    verbs: ["delete", "deletecollection"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: glueops-reader
+  namespace: {namespace}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: glueops-reader
+subjects:
+  - kind: Group
+    name: {group}-reader
+    apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: glueops-debugger
+  namespace: {namespace}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: glueops-debugger
+subjects:
+  - kind: Group
+    name: {group}-debugger
+    apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: glueops-operator
+  namespace: {namespace}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: glueops-operator
+subjects:
+  - kind: Group
+    name: {group}-operator
+    apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: glueops-super-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: Group
+    name: oidc:glueops-cluster-admins:super_admins
+    apiGroup: rbac.authorization.k8s.io
+"""
+    return manifest

--- a/app/util/kube_rbac.py
+++ b/app/util/kube_rbac.py
@@ -227,7 +227,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: glueops-reader
-  namespace: {namespace}
+  namespace: "{namespace}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -241,7 +241,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: glueops-debugger
-  namespace: {namespace}
+  namespace: "{namespace}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -255,7 +255,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: glueops-operator
-  namespace: {namespace}
+  namespace: "{namespace}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
## What

Adds `POST /v1/kube-rbac`, which generates the per-tenant Kubernetes RBAC that lets developers debug their own workloads (Lens / k9s) in their nonprod namespace via the kube-apiserver exposed by the existing `/v1/kube-apiserver` endpoint.

The endpoint emits the full bundle each call (idempotent under ArgoCD):
- **3 ClusterRoles** — `glueops-reader` (read-only), `glueops-debugger` (read + exec/attach/port-forward + ephemeral containers + rollout-restart + delete pods), `glueops-operator` (debugger + delete/deletecollection on any namespaced resource)
- **3 namespace-scoped RoleBindings** binding each role to the tenant's OIDC group
- the hardcoded `glueops-super-admins` → `cluster-admin` ClusterRoleBinding

## Parameterization

| Input | Use |
|-------|-----|
| `captain_domain` (e.g. `nonprod.jupiter.onglueops.rocks`) | first label (`nonprod`) is the RoleBinding namespace; full domain forms the OIDC group suffix |
| `tenant_github_organization_name` (e.g. `development-tenant-jupiter`) | OIDC group prefix → `oidc:<org>:<captain_domain>-<reader\|debugger\|operator>` |

Namespace derivation matches the existing `captain_manifests.py` convention (`captain_domain.split('.')[0]`).

## Implementation

Follows the `kube_apiserver.py` sibling pattern: a new `app/util/kube_rbac.py` f-string util returning a `PlainTextResponse`, with regex validation of both inputs (RFC-1123 hostname + GitHub-org login) to prevent YAML injection. New `KubeRbacManifestRequest` schema and route registration.

## Design notes

- **No `aggregationRule`** — the read set is repeated across the three ClusterRoles intentionally, because aggregation conflicts with ArgoCD's reconciliation of the controller-populated `rules: []`.
- `glueops-operator`'s `["*"]/["*"]` delete is scoped to the namespace by the RoleBinding; it can delete secrets/PVCs/rolebindings within that namespace (RBAC has no deny/exclude).

## Verification

Built the Docker image and exercised the endpoint:
- route registers in the OpenAPI spec
- output parses as a valid 7-document YAML stream (3 ClusterRole, 3 RoleBinding, 1 ClusterRoleBinding)
- RoleBinding namespace + OIDC subjects substitute correctly; super-admins binding hardcoded
- invalid `captain_domain` and newline-injection org name both return HTTP 422

## Out of scope

- Go CLI command + `cd cli && make generate` (the CLI OpenAPI spec is already stale on other endpoints — separate task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)