### PR TITLE
feat: add 'kubectl' segment to kube-rbac OIDC group names

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -158,7 +158,7 @@ async def create_kube_rbac_manifest(request: KubeRbacManifestRequest):
         Generate the ClusterRoles + namespace-scoped RoleBindings that let a tenant's developers
         debug their workloads (Lens/k9s) in their <environment> namespace via the kube-apiserver
         exposed by /v1/kube-apiserver. The namespace is the first label of captain_domain and the
-        RoleBinding subjects are oidc:<tenant_github_organization_name>:<captain_domain>-<role>.
+        RoleBinding subjects are oidc:<tenant_github_organization_name>:<captain_domain>-kubectl-<role>.
         Also includes the hardcoded glueops-super-admins -> cluster-admin ClusterRoleBinding.
     """
     return kube_rbac.create_kube_rbac_manifest(request)

--- a/app/schemas/schemas.py
+++ b/app/schemas/schemas.py
@@ -89,7 +89,7 @@ class KubeRbacManifestRequest(BaseModel):
     tenant_github_organization_name: str = Field(
         ...,
         example='development-tenant-foobar',
-        description='OIDC group prefix: oidc:<org>:<captain_domain>-<reader|debugger|operator>.'
+        description='OIDC group prefix: oidc:<org>:<captain_domain>-kubectl-<reader|debugger|operator>.'
     )
 
 class GitHubWorkflowRunStatusRequest(BaseModel):

--- a/app/util/kube_rbac.py
+++ b/app/util/kube_rbac.py
@@ -234,7 +234,7 @@ roleRef:
   name: glueops-reader
 subjects:
   - kind: Group
-    name: {group}-reader
+    name: {group}-kubectl-reader
     apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -248,7 +248,7 @@ roleRef:
   name: glueops-debugger
 subjects:
   - kind: Group
-    name: {group}-debugger
+    name: {group}-kubectl-debugger
     apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -262,7 +262,7 @@ roleRef:
   name: glueops-operator
 subjects:
   - kind: Group
-    name: {group}-operator
+    name: {group}-kubectl-operator
     apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## What

Follow-up to #43. Inserts a `kubectl` segment into the RoleBinding OIDC group subjects emitted by `/v1/kube-rbac`:

| Before (#43) | After |
|---|---|
| `oidc:<org>:<captain_domain>-reader` | `oidc:<org>:<captain_domain>-kubectl-reader` |
| `oidc:<org>:<captain_domain>-debugger` | `oidc:<org>:<captain_domain>-kubectl-debugger` |
| `oidc:<org>:<captain_domain>-operator` | `oidc:<org>:<captain_domain>-kubectl-operator` |

The hardcoded `glueops-super-admins` group (`oidc:glueops-cluster-admins:super_admins`) is unchanged.

Schema/route docstrings updated to match.

## Verification

Rebuilt the image and rendered the bundle: 7-doc YAML, all three RoleBinding subjects now carry the `kubectl` segment; super-admins binding unchanged.