### PR TITLE
feat: add reader-plus RBAC tier (read + port-forward)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -152,7 +152,7 @@ async def create_kube_apiserver_manifest(request: KubeApiserverManifestRequest):
     """
     return kube_apiserver.create_kube_apiserver_manifest(request)
 
-@app.post("/v1/kube-rbac", response_class=PlainTextResponse, summary="Generate developer-debug RBAC (reader/debugger/operator) for a tenant's namespace")
+@app.post("/v1/kube-rbac", response_class=PlainTextResponse, summary="Generate developer-debug RBAC (reader/reader-plus/debugger/operator) for a tenant's namespace")
 async def create_kube_rbac_manifest(request: KubeRbacManifestRequest):
     """
         Generate the ClusterRoles + namespace-scoped RoleBindings that let a tenant's developers

--- a/app/schemas/schemas.py
+++ b/app/schemas/schemas.py
@@ -89,7 +89,7 @@ class KubeRbacManifestRequest(BaseModel):
     tenant_github_organization_name: str = Field(
         ...,
         example='development-tenant-foobar',
-        description='OIDC group prefix: oidc:<org>:<captain_domain>-kubectl-<reader|debugger|operator>.'
+        description='OIDC group prefix: oidc:<org>:<captain_domain>-kubectl-<reader|reader-plus|debugger|operator>.'
     )
 
 class GitHubWorkflowRunStatusRequest(BaseModel):

--- a/app/util/kube_rbac.py
+++ b/app/util/kube_rbac.py
@@ -20,10 +20,11 @@ def create_kube_rbac_manifest(request):
         raise HTTPException(status_code=422, detail="Invalid tenant_github_organization_name.")
 
     namespace = captain_domain.split('.')[0]          # environment_name (e.g. "nonprod")
-    group = f"oidc:{tenant_org}:{captain_domain}"      # append -reader / -debugger / -operator
+    group = f"oidc:{tenant_org}:{captain_domain}"      # append -reader / -reader-plus / -debugger / -operator
 
     manifest = f"""# GlueOps developer-debug RBAC for kube-apiserver access (Lens / k9s).
-# No aggregationRules (conflicts with ArgoCD) -- each role repeats the read set; keep them in sync.
+# No aggregationRules (conflicts with ArgoCD) -- reader / reader-plus / debugger / operator each
+# repeat the read set; keep them in sync.
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -79,6 +80,66 @@ rules:
   - apiGroups: ["traefik.io"]  # add "traefik.containo.us" on older Traefik v2
     resources: ["ingressroutes", "ingressroutetcps", "middlewares", "middlewaretcps"]
     verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: glueops-reader-plus
+rules:
+  # read set (in sync with glueops-reader)
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/status
+      - pods/log
+      - services
+      - endpoints
+      - configmaps
+      - events
+      - persistentvolumeclaims
+      - serviceaccounts
+      - resourcequotas
+      - limitranges
+      - replicationcontrollers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["controllerrevisions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications", "applicationsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["external-secrets.io"]
+    resources: ["externalsecrets", "secretstores"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["traefik.io"]
+    resources: ["ingressroutes", "ingressroutetcps", "middlewares", "middlewaretcps"]
+    verbs: ["get", "list", "watch"]
+  # reader-plus only: port-forward (no exec/attach/delete/patch)
+  - apiGroups: [""]
+    resources: ["pods/portforward"]
+    verbs: ["create"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -235,6 +296,20 @@ roleRef:
 subjects:
   - kind: Group
     name: {group}-kubectl-reader
+    apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: glueops-reader-plus
+  namespace: "{namespace}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: glueops-reader-plus
+subjects:
+  - kind: Group
+    name: {group}-kubectl-reader-plus
     apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary

- Adds a new `glueops-reader-plus` ClusterRole and matching namespace-scoped RoleBinding to `/v1/kube-rbac` output.
- Reader Plus is identical to `glueops-reader` plus a single rule granting `pods/portforward` create — no exec, attach, ephemeral containers, restart, or delete.
- Subjects bind to OIDC group `{group}-kubectl-reader-plus` in the tenant's namespace (first label of `captain_domain`).
- Endpoint `summary=` and `KubeRbacManifestRequest.tenant_github_organization_name` description updated to list the new role.

## Review

Reviewed by an internal expert panel (K8s RBAC/security, FastAPI/Python, docs, cross-repo consistency). No blockers:

- ClusterRole read-set byte-identical to `glueops-reader`; only delta is `pods/portforward: create`.
- Debugger ⊇ Reader Plus ⊇ Reader holds at the rule level (debugger already had portforward).
- F-string rendered cleanly with sample inputs; all 9 YAML documents parse via `yaml.safe_load_all`.
- Reader/debugger/operator/super-admins rules and bindings unchanged.
- Port-forward is scoped to the tenant namespace via `RoleBinding`, not cluster-wide.

Companion docs PR: GlueOps/glueops-dev (new "Reader Plus" row in the Access tiers table).

## Test plan

- [ ] `curl -X POST .../v1/kube-rbac` with a sample request and confirm the manifest now contains the `glueops-reader-plus` ClusterRole + RoleBinding.
- [ ] Apply the manifest in a test cluster.
- [ ] Add a user to a `{captain_domain}-kubectl-reader-plus` GitHub team and verify they can `kubectl port-forward` in their namespace.
- [ ] Verify the same user cannot `kubectl exec`, `attach`, or `delete` pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)